### PR TITLE
Add destroy alias for connection

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
 	"printWidth": 120,
 	"tabWidth": 4,
 	"trailingComma": "all",
-	"useTabs": true
+	"useTabs": true,
+	"endOfLine": "auto"
 }

--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ public Disconnect(): void
 ```
 Disconnects the connection.
 
+### `Connection.Destroy`
+```ts
+public Destroy(): void
+```
+Alias for `Connection.Disconnect`.
+
 ## Example
 
 ```ts

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,13 @@ export class Connection<T> {
 			}
 		}
 	}
+
+	/**
+	 * Alias for `Disconnect`.
+	 */
+	public Destroy() {
+		this.Disconnect();
+	}
 }
 
 /**


### PR DESCRIPTION
To make connections compatible with @rbxts/maid without additional workarounds.

I was trying to migrate from @rbxts/signal, but ran into errors where my maids would not accept the signals created by this package: `[Maid.GiveTask] - Gave table task without .Destroy`. Adding this alias would make it easier to migrate to this package.